### PR TITLE
README.md Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Next, you and your partner should both add the class repository as an upstream g
 $ git remote add upstream https://github.com/msu/csci-468-spring2021.git
 $ git pull upstream main
 $ git push origin master
+or if your origin branch is titled 'main'
+$ git push origin main
 ```
 This will synchronize your private repository with the class repository.
 


### PR DESCRIPTION
As I was adding the class repo as an upstream repo, I noticed that the 'master' branch was actually titled 'main'. Apparently, GitHub recently decided to dump the term 'master' for a more neutral term. The changes in this README replace the instances of anything having to do with an upstream 'master' branch with the correct 'main' branch title. Also, I quickly want to piggy-back off of what Teyler said in his pull request; you are an awesome professor. I am thoroughly looking forward to taking this class. Thank you!